### PR TITLE
feat(env): BE api now using caddy & nip.io instead of aws api gateway

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -52,4 +52,4 @@ REACT_APP_KICKSTARTER_SUBGRAPH = "https://api.thegraph.com/subgraphs/name/umaism
 REACT_APP_WHITELABEL_FACTORY_ADDRESS = "0xe2984D883Dc7606114b528F8Fb650965e4D08592"
 REACT_APP_WHITELABEL_NFT_CLIENT = "https://api.thegraph.com/subgraphs/name/sxio/staging"
 
-REACT_APP_BACKEND_API = "https://cz2mo9sn34.execute-api.us-east-2.amazonaws.com"
+REACT_APP_BACKEND_API = "https://staging-52.14.246.84.nip.io/"

--- a/.env.production
+++ b/.env.production
@@ -50,4 +50,4 @@ REACT_APP_KICKSTARTER_SUBGRAPH = "https://api.thegraph.com/subgraphs/name/koda-f
 REACT_APP_WHITELABEL_FACTORY_ADDRESS = ""
 REACT_APP_WHITELABEL_NFT_CLIENT = ""
 
-REACT_APP_BACKEND_API = "https://mvw07aurfa.execute-api.us-east-2.amazonaws.com"
+REACT_APP_BACKEND_API = "https://production-52.14.246.84.nip.io/"


### PR DESCRIPTION
since aws api gateway only allow up to 10MB payload size (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html), i'm switching it out to Caddy and nip.io.
Caddy will handle the reverse proxy while nip.io will handle the https

related PR: https://github.com/Koda-Finance/summitswap-backend/pull/4

configured caddy & nip.io:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/19347052/210946562-b68dcf19-361f-4dce-a0cf-d26e1c3ec82b.png">
